### PR TITLE
[SASS-10663] Add secondary Agent authentication logic and feature switch

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -16,14 +16,25 @@
 
 package config
 
+import com.google.inject.ImplementedBy
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.Duration
 
-@Singleton
-class AppConfig @Inject()(config: ServicesConfig) {
-  def mongoTTL: Long = Duration(config.getString("mongodb.timeToLive")).toDays.toInt
+@ImplementedBy(classOf[AppConfigImpl])
+trait AppConfig {
+  def mongoTTL: Long
+  def replaceIndexes: Boolean
+  def emaSupportingAgentsEnabled: Boolean
+}
 
-  val replaceIndexes: Boolean = config.getBoolean("feature-switch.replaceIndexes")
+@Singleton
+class AppConfigImpl @Inject()(config: ServicesConfig) extends AppConfig {
+  override lazy val mongoTTL: Long = Duration(config.getString("mongodb.timeToLive")).toDays.toInt
+
+  override lazy val replaceIndexes: Boolean = config.getBoolean("feature-switch.replaceIndexes")
+
+  override def emaSupportingAgentsEnabled: Boolean =
+    config.getBoolean("feature-switch.ema-supporting-agents-enabled")
 }

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -17,8 +17,8 @@
 package config
 
 import controllers.predicates.{AuthorisedAction, EarlyPrivateLaunchAuthorisedAction, IdentifierAction}
-import play.api.{Configuration, Environment}
 import play.api.inject.Binding
+import play.api.{Configuration, Environment}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
 
 import java.time.Clock
@@ -35,7 +35,7 @@ class Module extends play.api.inject.Module {
       }
 
     Seq(
-      bind[AppConfig].toSelf.eagerly(),
+      bind[AppConfig].to[AppConfigImpl].eagerly(),
       bind[Clock].toInstance(Clock.systemUTC()),
       bind[Encrypter with Decrypter].toProvider[CryptoProvider],
       authBinding

--- a/app/models/Enrolment.scala
+++ b/app/models/Enrolment.scala
@@ -19,7 +19,12 @@ package models
 abstract class Enrolment(val key: String, val value: String)
 
 object Enrolment {
-  case object MtdIncomeTax extends Enrolment(key = "HMRC-MTD-IT", value = "MTDITID")
-
+  case object Individual extends Enrolment(key = "HMRC-MTD-IT", value = "MTDITID")
   case object Agent extends Enrolment(key = "HMRC-AS-AGENT", value = "AgentReferenceNumber")
+  case object SupportingAgent extends Enrolment(key = "HMRC-MTD-IT-SUPP", value = "MTDITID")
+}
+
+object DelegatedAuthRules {
+  val agentDelegatedAuthRule = "mtd-it-auth"
+  val supportingAgentDelegatedAuthRule = "mtd-it-auth-supp"
 }

--- a/app/models/User.scala
+++ b/app/models/User.scala
@@ -18,6 +18,8 @@ package models
 
 import play.api.mvc.{Request, WrappedRequest}
 
-case class User[T](mtditid: String, arn: Option[String])(implicit val request: Request[T]) extends WrappedRequest[T](request) {
-  def isAgent: Boolean = arn.nonEmpty
+case class User[T](mtditid: String,
+                   arn: Option[String],
+                   isSecondaryAgent: Boolean = false)(implicit val request: Request[T]) extends WrappedRequest[T](request) {
+  val isAgent = arn.isDefined
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -76,4 +76,5 @@ microservice {
 feature-switch {
     earlyPrivateLaunch = false
     replaceIndexes = false
+    ema-supporting-agents-enabled = true
 }

--- a/test/controllers/TaskListDataControllerSpec.scala
+++ b/test/controllers/TaskListDataControllerSpec.scala
@@ -48,8 +48,8 @@ class TaskListDataControllerSpec
     with BeforeAndAfterEach {
 
   private val enrolments: Enrolments = Enrolments(Set(
-    Enrolment(models.Enrolment.MtdIncomeTax.key,
-      Seq(EnrolmentIdentifier(models.Enrolment.MtdIncomeTax.value, "1234567890")), "Activated")
+    Enrolment(models.Enrolment.Individual.key,
+      Seq(EnrolmentIdentifier(models.Enrolment.Individual.value, "1234567890")), "Activated")
   ))
 
   private val authResponse: Some[AffinityGroup] ~ Enrolments =

--- a/test/controllers/UserDataControllerSpec.scala
+++ b/test/controllers/UserDataControllerSpec.scala
@@ -48,8 +48,8 @@ class UserDataControllerSpec
     with BeforeAndAfterEach {
 
   private val enrolments: Enrolments = Enrolments(Set(
-    Enrolment(models.Enrolment.MtdIncomeTax.key,
-      Seq(EnrolmentIdentifier(models.Enrolment.MtdIncomeTax.value, "1234567890")), "Activated")
+    Enrolment(models.Enrolment.Individual.key,
+      Seq(EnrolmentIdentifier(models.Enrolment.Individual.value, "1234567890")), "Activated")
   ))
 
   private val authResponse: Some[AffinityGroup] ~ Enrolments =


### PR DESCRIPTION
App-config PR(s) are covered by:
- https://github.com/hmrc/app-config-base/pull/11426
- https://github.com/hmrc/app-config-qa/pull/24190
- https://github.com/hmrc/app-config-staging/pull/16502
- https://github.com/hmrc/app-config-production/pull/24162