### PR TITLE
ORD-734: Upgrade income-tax-tailor-return to Scala 3

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = 3.7.15
+runner.dialect = scala3

--- a/app/models/mongo/TaskListData.scala
+++ b/app/models/mongo/TaskListData.scala
@@ -40,7 +40,7 @@ object TaskListData {
         (__ \ "taxYear").read[Int].filter(_.toString.matches("^20\\d{2}$")) and
         (__ \ "data").read[JsObject] and
         (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
-      ) (TaskListData.apply _)
+      ) (TaskListData.apply)
   }
 
   val writes: OWrites[TaskListData] = {
@@ -49,7 +49,7 @@ object TaskListData {
         (__ \ "taxYear").write[Int] and
         (__ \ "data").write[JsObject] and
         (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
-      ) (unlift(TaskListData.unapply))
+      ) (tld => (tld.mtdItId, tld.taxYear, tld.data, tld.lastUpdated))
   }
 
   implicit val format: OFormat[TaskListData] = OFormat(reads, writes)

--- a/app/models/mongo/UserData.scala
+++ b/app/models/mongo/UserData.scala
@@ -16,6 +16,7 @@
 
 package models.mongo
 
+import play.api.libs.functional.syntax._
 import play.api.libs.json._
 import uk.gov.hmrc.crypto.Sensitive._
 import uk.gov.hmrc.crypto.json.JsonEncryption
@@ -35,35 +36,26 @@ case class UserData(
   object UserData {
 
     val reads: Reads[UserData] = {
-
-      import play.api.libs.functional.syntax._
-
       (
         (__ \ "mtdItId").read[String] and
           (__ \ "taxYear").read[Int].filter(_.toString.matches("^20\\d{2}$")) and
           (__ \ "data").read[JsObject] and
           (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
-        ) (UserData.apply _)
+        ) (UserData.apply)
     }
 
     val writes: OWrites[UserData] = {
-
-      import play.api.libs.functional.syntax._
-
       (
         (__ \ "mtdItId").write[String] and
           (__ \ "taxYear").write[Int] and
           (__ \ "data").write[JsObject] and
           (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
-        ) (unlift(UserData.unapply))
+        ) (ud => (ud.mtdItId, ud.taxYear, ud.data, ud.lastUpdated))
     }
 
     implicit val format: OFormat[UserData] = OFormat(reads, writes)
 
     def encryptedFormat(implicit crypto: Encrypter with Decrypter): OFormat[UserData] = {
-
-      import play.api.libs.functional.syntax._
-
       implicit val sensitiveFormat: Format[SensitiveString] =
         JsonEncryption.sensitiveEncrypterDecrypter(SensitiveString.apply)
 

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ import uk.gov.hmrc.DefaultBuildSettings
 val appName = "income-tax-tailor-return"
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.18"
+ThisBuild / scalaVersion := "3.3.7"
 
 lazy val coverageSettings: Seq[Setting[?]] = {
   import scoverage.ScoverageKeys
@@ -52,8 +52,10 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(PlayScala, SbtDistributablesPlugin)
   .settings(
     libraryDependencies ++= AppDependencies(),
-    scalacOptions += "-Wconf:cat=unused-imports&src=html/.*:s",
-    scalacOptions += "-Wconf:src=routes/.*:s"
+    scalacOptions += "-Werror",
+    scalacOptions += "-Wconf:src=html/.*:s",
+    scalacOptions += "-Wconf:src=routes/.*:s",
+    scalacOptions ~= (_.distinct)
   )
   .configs(Test)
   .settings(PlayKeys.playDefaultPort := 9383)

--- a/it/test/repositories/TaskListDataRepositorySpec.scala
+++ b/it/test/repositories/TaskListDataRepositorySpec.scala
@@ -56,7 +56,7 @@ class TaskListDataRepositorySpec
   private implicit val crypto: Encrypter with Decrypter =
     SymmetricCryptoFactory.aesGcmCryptoFromConfig("crypto", configuration.underlying)
 
-  protected override val repository = new TaskListDataRepository(
+  protected override val repository: TaskListDataRepository = new TaskListDataRepository(
     mongoComponent = mongoComponent,
     appConfig = appConfig,
     clock = stubClock

--- a/it/test/repositories/UserDataRepositorySpec.scala
+++ b/it/test/repositories/UserDataRepositorySpec.scala
@@ -56,7 +56,7 @@ class UserDataRepositorySpec
   private implicit val crypto: Encrypter with Decrypter =
     SymmetricCryptoFactory.aesGcmCryptoFromConfig("crypto", configuration.underlying)
 
-  protected override val repository = new UserDataRepository(
+  protected override val repository: UserDataRepository = new UserDataRepository(
     mongoComponent = mongoComponent,
     appConfig = appConfig,
     clock = stubClock

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -32,7 +32,7 @@ object AppDependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"   % bootstrapVersion,
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30"  % hmrcMongoVersion,
-    "org.mockito"             %% "mockito-scala"            % "2.1.0",
+    "org.mockito"             %% "mockito-scala"            % "2.2.1",
     "org.scalatest"           %% "scalatest"                % "3.2.19"
   ).map(_ % Test)
 


### PR DESCRIPTION
## ORD-734: Upgrade income-tax-tailor-return to Scala 3

Migrates `income-tax-tailor-return` from Scala 2.13.18 to Scala 3.3.7 (LTS).

### Changes

- `.scalafmt.conf` — created with `runner.dialect = scala3`
- `app/models/mongo/TaskListData.scala` — eta-expansion fix, `unlift` → explicit lambda
- `app/models/mongo/UserData.scala` — file-level import, eta-expansion fix, `unlift` → explicit lambda
- `build.sbt` — `scalaVersion` 2.13.18 → 3.3.7; `-Werror`; Scala 3-compatible `-Wconf`; `scalacOptions ~= (_.distinct)`
- `it/test/repositories/TaskListDataRepositorySpec.scala` — explicit type on `repository` override (Scala 3 return-type widening)
- `it/test/repositories/UserDataRepositorySpec.scala` — explicit type on `repository` override (Scala 3 return-type widening)
- `project/AppDependencies.scala` — `mockito-scala` 2.1.0 → 2.2.1 (Scala 3 artefact)

### Tests

| Suite | Result |
|---|---|
| Unit tests | ✅ 41 / 41 passed |
| Integration tests | ✅ 22 / 22 passed |

---

Jira: [ORD-734](https://jira.tools.tax.service.gov.uk/browse/ORD-734)

*This PR was created automatically by [Q Branch](https://github.com/hmrc/q-branch) via `complete-jira-ticket`.*
